### PR TITLE
Fixing the dependency for alpha flavor.

### DIFF
--- a/fyber-sample-app/build.gradle
+++ b/fyber-sample-app/build.gradle
@@ -142,6 +142,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-v4'
     }
     implementation 'com.android.support:appcompat-v7:27.0.2'
+    compileOnly 'com.fyber:fyber-annotations:1.3.0'
 
     // 3rd party lib for view dependencies injection
     implementation 'com.jakewharton:butterknife:8.8.1'
@@ -156,7 +157,6 @@ dependencies {
     // If you want to use mediation you must uncomment the following dependencies:
     // Also you have to uncomment the @FyberSDK annotation in the MainActivity
     // Don't forget either to add your mediation bundles here with `annotationProcessor` configuration
-//    compileOnly 'com.fyber:fyber-annotations:1.3.0'
 //    annotationProcessor 'com.fyber:fyber-annotations:1.3.0'
 //    annotationProcessor 'com.fyber:fyber-annotations-compiler:1.5.0'
 //

--- a/fyber-sample-app/src/alpha/java/com/fyber/sampleapp/AlphaMainActivity.java
+++ b/fyber-sample-app/src/alpha/java/com/fyber/sampleapp/AlphaMainActivity.java
@@ -2,7 +2,6 @@ package com.fyber.sampleapp;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.crashlytics.android.Crashlytics;
 import com.fyber.annotations.FyberSDK;


### PR DESCRIPTION
The `alpha` flavor is using the `@FyberSDK` annotation. When building from Android Studio selecting the `internal` flavor, everything seems okay. But selecting the `alpha` one doesn't build because the dependency to the annotations is commented out.